### PR TITLE
Fixed compiler error

### DIFF
--- a/libsrc/socket/Socket.cpp
+++ b/libsrc/socket/Socket.cpp
@@ -30,6 +30,7 @@
 #include "Socket.h"
 #include <iostream>
 #include <string.h>
+#include <unistd.h>
 
 using namespace std;
 #ifndef MSG_DONTWAIT


### PR DESCRIPTION
/home/wrk/izip/git/opensource/pfff/libsrc/socket/Socket.cpp: In member function 'void Socket::Close()':
/home/wrk/izip/git/opensource/pfff/libsrc/socket/Socket.cpp:105:4: error: 'close' was not declared in this scope
