### PR TITLE
Fix building on Apple platforms

### DIFF
--- a/src/PfffBlockReader.cpp
+++ b/src/PfffBlockReader.cpp
@@ -60,6 +60,10 @@ LocalFileBlockReader::~LocalFileBlockReader() {
 	// http://www.cygwin.com/faq/faq.programming.html#faq.programming.stat64
 	#define stat64 stat
 #endif
+#ifdef __APPLE__
+    // stat64 is not used on Darwin, just use struct stat which expands to __DARWIN_STRUCT_STAT64
+    #define stat64 stat
+#endif
 
 long long LocalFileBlockReader::_size() {
     struct stat64 s;

--- a/tests/src/TestPlatform.cpp
+++ b/tests/src/TestPlatform.cpp
@@ -11,6 +11,10 @@
 	// http://www.cygwin.com/faq/faq.programming.html#faq.programming.stat64
 	#define stat64 stat
 #endif
+#ifdef __APPLE__
+    // stat64 is not used on Darwin, just use struct stat which expands to __DARWIN_STRUCT_STAT64
+    #define stat64 stat
+#endif
 
 TEST(TestPlatform) {
     // Make sure that stat64.st_size is 64-bit

--- a/tests/src/test_util.cpp
+++ b/tests/src/test_util.cpp
@@ -27,6 +27,10 @@ uint64_t FileFixture::next_uint64() {
 string FileFixture::next_line(ifstream& infile) {
     string result;
     getline(infile, result);
+
+    if (result.empty())
+        return result;
+
     // Our files were made on windows so we might have end of line problems
     if (result[result.size()-1] == '\n' || result[result.size()-1] == '\r')
         result.resize(result.size()-1);


### PR DESCRIPTION
Similarly to Cygwin, Apple platforms don't define `stat64`, but the stat structure is a 64 bit structure.

This also fixes a test that was crashing at runtime; the line-by-line reader may read an empty string on macOS.